### PR TITLE
Tether clean

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -45,14 +45,15 @@ jobs:
           git config --global --add safe.directory '*'
           conda install anaconda-client conda-build conda-verify
           conda build conda-package/ --output-folder ./pkg/ --no-include-recipe --no-anaconda-upload -c conda-forge
+          echo ./pkg/linux-64/rdock-*.tar.bz2; ls -l ./pkg/linux-64
 
       - name: Test package
         run: |
-          conda install -q -y ./pkg/linux-64/rdock-*.tar.bz2
+          conda install -q -y ./pkg/linux-64/rdock-*.conda
           conda install -q -y pytest
           pytest ./tests/
 
       - name: Upload to conda
         shell: bash -l {0}
         run: |
-          anaconda -t ${{ secrets.ANACONDA_TOKEN_BASIC }} upload -u acellera ./pkg/*/rdock-*.tar.bz2
+          anaconda -t ${{ secrets.ANACONDA_TOKEN_BASIC }} upload -u acellera ./pkg/*/rdock-*.conda


### PR DESCRIPTION
According to chat and a blog post, conda build now produces, by default, .conda files, not tar.bz2 ones. This causes the install step to fail.

Run conda install -q -y ./pkg/linux-64/rdock-***.tar.bz2**