### PR TITLE
Fix segfault on SDF data fields with long names or many values

### DIFF
--- a/include/RbtBaseFileSource.h
+++ b/include/RbtBaseFileSource.h
@@ -25,9 +25,6 @@ typedef RbtString RbtFileRec;
 typedef vector<RbtFileRec> RbtFileRecList;
 typedef RbtFileRecList::iterator RbtFileRecListIter;
 
-//Max line length expected in file
-const int MAXLINELENGTH = 255;
-
 class RbtBaseFileSource
 {
  public:
@@ -88,7 +85,6 @@ class RbtBaseFileSource
   RbtString m_strFileName;
   RbtBool m_bReadOK;//For use by Read
   ifstream m_fileIn;
-  char* m_szBuf;//Line buffer
   RbtBool m_bFileOpen;//Keep track of whether we've opened the file or not
   RbtBool m_bMultiRec;//Is file multi-record ?
   RbtString m_strRecDelim;//Record delimiter

--- a/src/lib/RbtBaseFileSource.cxx
+++ b/src/lib/RbtBaseFileSource.cxx
@@ -25,7 +25,6 @@
 RbtBaseFileSource::RbtBaseFileSource(const RbtString& fileName) : m_bMultiRec(false), m_bFileOpen(false)
 {
 	m_strFileName = fileName;
-	m_szBuf = new char[MAXLINELENGTH+1];//DM 24 Mar - allocate line buffer
 	ClearCache();
 	_RBTOBJECTCOUNTER_CONSTR_("RbtBaseFileSource");
 }
@@ -35,7 +34,6 @@ RbtBaseFileSource::RbtBaseFileSource(const RbtString& fileName) : m_bMultiRec(fa
 m_bMultiRec(true), m_strRecDelim(strRecDelim), m_bFileOpen(false)
 {
 	m_strFileName = fileName;
-	m_szBuf = new char[MAXLINELENGTH+1];//DM 24 Mar - allocate line buffer
 	ClearCache();
 	_RBTOBJECTCOUNTER_CONSTR_("RbtBaseFileSource");
 }
@@ -46,7 +44,6 @@ RbtBaseFileSource::~RbtBaseFileSource()
 {
 	Close();
 	ClearCache();
-	delete [] m_szBuf;//DM 24 Mar - delete line buffer
 	_RBTOBJECTCOUNTER_DESTR_("RbtBaseFileSource");
 }
 
@@ -137,6 +134,9 @@ void RbtBaseFileSource::Rewind()
 
 void RbtBaseFileSource::Read(RbtBool aDelimiterAtEnd) throw (RbtError)
 {
+	//DM - read into a std::string so there is no limit on line length;
+	//long SD data field names or values no longer overflow a fixed buffer
+	RbtString strBuf;
 	//If we haven't already read the file, do it now
 	if (!m_bReadOK) {
 		if(aDelimiterAtEnd) {
@@ -149,19 +149,19 @@ void RbtBaseFileSource::Read(RbtBool aDelimiterAtEnd) throw (RbtError)
 				if (m_bMultiRec) {
 					const char* cszRecDelim = m_strRecDelim.c_str();
 					RbtInt n = strlen(cszRecDelim);
-					while( (m_fileIn.getline(m_szBuf,MAXLINELENGTH))  &&
-						(strncmp(m_szBuf,cszRecDelim,n) != 0) ) {
+					while( (std::getline(m_fileIn,strBuf))  &&
+						(strncmp(strBuf.c_str(),cszRecDelim,n) != 0) ) {
 #ifdef _DEBUG
-							cout << m_szBuf << endl;
+							cout << strBuf << endl;
 #endif //_DEBUG
-							m_lineRecs.push_back(m_szBuf);
+							m_lineRecs.push_back(strBuf);
 						}
 				}
 				//Single-record read
 				//Read entire file and close immediately
 				else {
-					while(m_fileIn.getline(m_szBuf,MAXLINELENGTH)) {
-						m_lineRecs.push_back(m_szBuf);
+					while(std::getline(m_fileIn,strBuf)) {
+						m_lineRecs.push_back(strBuf);
 					}
 					Close();
 				}
@@ -186,22 +186,22 @@ void RbtBaseFileSource::Read(RbtBool aDelimiterAtEnd) throw (RbtError)
 					RbtInt 		n			= strlen(cszRecDelim);
 					// skip to the header stuff until the first record
 					// AND the first delimiter line
-					while( (m_fileIn.getline(m_szBuf,MAXLINELENGTH))  && 
-						(strncmp(m_szBuf,cszRecDelim,n) != 0) )
+					while( (std::getline(m_fileIn,strBuf))  &&
+						(strncmp(strBuf.c_str(),cszRecDelim,n) != 0) )
 						;
-					while( (m_fileIn.getline(m_szBuf,MAXLINELENGTH))  && 
-						(strncmp(m_szBuf,cszRecDelim,n) != 0) ) {
+					while( (std::getline(m_fileIn,strBuf))  &&
+						(strncmp(strBuf.c_str(),cszRecDelim,n) != 0) ) {
 #ifdef _DEBUG
-							cout << m_szBuf << endl;
+							cout << strBuf << endl;
 #endif //_DEBUG
-							m_lineRecs.push_back(m_szBuf);
+							m_lineRecs.push_back(strBuf);
 						}
 				}
 				//Single-record read
 				//Read entire file and close immediately
 				else {
-					while(m_fileIn.getline(m_szBuf,MAXLINELENGTH)) {
-						m_lineRecs.push_back(m_szBuf);
+					while(std::getline(m_fileIn,strBuf)) {
+						m_lineRecs.push_back(strBuf);
 					}
 					Close();
 				}

--- a/src/lib/RbtMdlFileSource.cxx
+++ b/src/lib/RbtMdlFileSource.cxx
@@ -202,6 +202,12 @@ void RbtMdlFileSource::Parse() throw(RbtError)
               sl.push_back(*fileIter);
             }
             m_dataMap[fieldName] = RbtVariant(sl);
+            // The inner loop above may have advanced fileIter to fileEnd
+            // (data value runs to the end of the record with no trailing
+            // blank line). Stop here so the outer loop's increment does not
+            // step past fileEnd and dereference an invalid iterator.
+            if (fileIter == fileEnd)
+              break;
           }
         }
       }


### PR DESCRIPTION
Tethered docking writes all tethered atom indices on a single SDF data field line (TETHERED ATOMS), which can easily exceed the old 255-char line buffer. Two bugs combined to crash rbcavity/rbdock when reading such files:

1. RbtBaseFileSource read every line into a fixed char[256] buffer via istream::getline. Lines over 254 chars were silently truncated and set the stream failbit, halting the read mid-record so the trailing blank line and $$$$ delimiter were dropped. Now read into a std::string with std::getline, so line length is unbounded.

2. RbtMdlFileSource::Parse advanced the record iterator past fileEnd: the inner data-value loop can leave fileIter == fileEnd, then the outer for-loop's fileIter++ stepped past the end and dereferenced an invalid iterator. Guard with a break when fileEnd is reached.

Verified: reproduced the SIGSEGV with long property name/value fields (both now succeed), and confirmed docking coordinates and scores are byte-identical to a clean build of the original source.