### PR TITLE
CI: install conda-build into base env so `conda build` is available

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash -l {0}
         run: |
           git config --global --add safe.directory '*'
-          conda install anaconda-client conda-build conda-verify
+          conda install -n base -y anaconda-client conda-build conda-verify
           conda build conda-package/ --output-folder ./pkg/ --no-include-recipe --no-anaconda-upload -c conda-forge
 
       - name: Test package


### PR DESCRIPTION
conda-build was installed into the activated deploy-env, but the `conda build` subcommand is a plugin that conda only discovers from the base environment where conda itself runs. As a result `conda build` failed with "invalid choice: 'build'". Install into -n base (and add -y to avoid the interactive prompt) so the subcommand is registered.