### PR TITLE
CI: use standalone `conda-build` in deploy-env instead of `conda build`

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -40,8 +40,8 @@ jobs:
         shell: bash -l {0}
         run: |
           git config --global --add safe.directory '*'
-          conda install -n base -y anaconda-client conda-build conda-verify
-          conda build conda-package/ --output-folder ./pkg/ --no-include-recipe --no-anaconda-upload -c conda-forge
+          conda install -y anaconda-client conda-build conda-verify
+          conda-build conda-package/ --output-folder ./pkg/ --no-include-recipe --no-anaconda-upload -c conda-forge
 
       - name: Test package
         run: |


### PR DESCRIPTION
Installing conda-build into base let the `conda build` subcommand resolve, but base pins Python 3.13 and conda-verify needs `future` (no 3.13 build), making the solve unsatisfiable. Install into the active deploy-env (Python 3.10, where it solves) and call the standalone `conda-build` console script, which is on PATH there — avoiding the subcommand-plugin requirement that forced the base install.