### PR TITLE
Bump conda package version to 2022.0+5

### DIFF
--- a/conda-package/meta.yaml
+++ b/conda-package/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: rdock
-  version: "2022.0+4"
+  version: "2022.0+5"
 
 source:
   path: ..


### PR DESCRIPTION
The 2022.0+4 artifact is already published on anaconda.org, so the upload step returns a 409 conflict. Bump the +N suffix (their release convention) to publish this SDF long-property segfault fix.