### PR TITLE
Improve tethered docking: near-reference init population + smooth tet…

### DIFF
--- a/conda-package/meta.yaml
+++ b/conda-package/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: rdock
-  version: "2022.0+5"
+  version: "2022.0+6"
 
 source:
   path: ..

--- a/src/lib/RbtChromDihedralElement.cxx
+++ b/src/lib/RbtChromDihedralElement.cxx
@@ -49,8 +49,19 @@ void RbtChromDihedralElement::Randomise() {
     RbtDouble delta;
     switch (m_spRefData->GetMode()) {
         case RbtChromElement::TETHERED:
-            delta = 2.0 * maxDelta * GetRand().GetRandom01() - maxDelta;
-            m_value = StandardisedValue(m_spRefData->GetInitialValue() + delta);
+            // Seed the initial population close to the tethered reference
+            // conformation instead of scattering each dihedral uniformly across
+            // +/-MAX_DIHEDRAL (which throws away the reference geometry we are
+            // tethered to). Every dihedral gets an independent tiny random
+            // perturbation (at most 1 degree, and never beyond the tether
+            // limit): the population stays near the reference while still giving
+            // the GA per-dihedral diversity across the whole chromosome. The
+            // GA's Mutate() still explores the full tethered range during search.
+            {
+                const RbtDouble tinyDelta = (maxDelta < 1.0) ? maxDelta : 1.0;
+                delta = 2.0 * tinyDelta * GetRand().GetRandom01() - tinyDelta;
+                m_value = StandardisedValue(m_spRefData->GetInitialValue() + delta);
+            }
             break;
         case RbtChromElement::FREE:
             m_value = 360.0 * GetRand().GetRandom01() - 180.0;

--- a/src/lib/RbtTetherSF.cxx
+++ b/src/lib/RbtTetherSF.cxx
@@ -78,6 +78,8 @@ void RbtTetherSF::SetupReceptor()
 void RbtTetherSF::SetupLigand()
 {
   m_ligAtomList.clear();
+  m_tetherCoords.clear(); // DM - must reset, else tether coords accumulate across
+                          // successive ligands and the size check below wrongly fails
   if (GetLigand().Null())
     return;
 
@@ -111,10 +113,17 @@ RbtDouble RbtTetherSF::RawScore() const
   RbtInt i = 0;
   for (RbtIntListConstIter iter = m_tetherAtomList.begin(); iter < m_tetherAtomList.end(); iter++, i++)
   {
-    RbtDouble dist = Rbt::Length2(m_ligAtomList[*iter]->GetCoords(), m_tetherCoords[i]);
-    if (dist > distance_threshold)
+    // Smooth restraint: zero penalty while the atom stays within
+    // DISTANCE_THRESHOLD (in Angstroms) of its tether point, then linear in the
+    // displacement beyond it. This avoids the old discontinuous step penalty,
+    // which gave the optimizer no gradient toward compliance (an atom 5 A out
+    // scored the same as one just over the threshold), while keeping the
+    // penalty on a comparable scale (penalty_factor per Angstrom of drift).
+    RbtDouble dist = Rbt::Length(m_ligAtomList[*iter]->GetCoords(), m_tetherCoords[i]);
+    RbtDouble dr = dist - distance_threshold;
+    if (dr > 0.0)
     {
-      score += (penalty_factor * 1.0);
+      score += penalty_factor * dr;
     }
   }
 


### PR DESCRIPTION
…her penalty

Tethered-mode initial population (RbtChromDihedralElement::Randomise): instead of scattering each tethered dihedral uniformly across +/-MAX_DIHEDRAL (which discards the reference geometry we are tethered to), perturb every dihedral by an independent tiny delta (<= 1 degree, clamped to the tether limit). The population now starts close to the reference while retaining per-dihedral diversity for the GA; Mutate() still explores the full tethered range during the search. Only the TETHERED branch changes - FREE and fixed dihedrals, and free docking, are unaffected.

Tether scoring function (RbtTetherSF):
- RawScore now applies a smooth linear penalty in the displacement beyond DISTANCE_THRESHOLD (using real Angstrom distance), replacing the discontinuous step penalty that gave the optimizer no gradient toward compliance. The threshold is now compared in Angstroms (previously a squared distance was compared against the un-squared threshold).
- SetupLigand now clears m_tetherCoords so tether coordinates no longer accumulate across successive ligands (which wrongly tripped the size check).

Bump conda package version to 2022.0+6.